### PR TITLE
test case to address failure in loading Nvidia Nim model images then error message should be displayed.

### DIFF
--- a/frontend/src/__tests__/cypress/cypress.config.ts
+++ b/frontend/src/__tests__/cypress/cypress.config.ts
@@ -16,6 +16,7 @@ import { env, cypressEnv, BASE_URL } from '~/__tests__/cypress/cypress/utils/tes
 const resultsDir = `${env.CY_RESULTS_DIR || 'results'}/${env.CY_MOCK ? 'mocked' : 'e2e'}`;
 
 export default defineConfig({
+  experimentalStudio: false,
   experimentalMemoryManagement: true,
   // Use relative path as a workaround to https://github.com/cypress-io/cypress/issues/6406
   reporter: '../../../node_modules/cypress-multi-reporters',

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/modelServingNim.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/modelServingNim.cy.ts
@@ -198,6 +198,18 @@ describe('NIM Model Serving', () => {
 
         validateNvidiaNimModel(findNimModelDeployButton());
       });
+
+      it("When there is a failure in loading Nvidia Nim model images then error message should be displayed.", () => {
+        initInterceptsToEnableNim({});
+        const componentName = 'overview';
+        projectDetails.visitSection('test-project', componentName);
+        const overviewComponent = projectDetails.findComponent(componentName);
+        overviewComponent.should('exist');
+        const deployModelButton = overviewComponent.findByTestId('model-serving-platform-button');
+        deployModelButton.should('exist');
+        deployModelButton.click()
+        cy.contains('There was a problem fetching the NIM models. Please try again later.')
+      });
     });
 
     describe('When NIM feature is disabled', () => {

--- a/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/modelServingNim.cy.ts
+++ b/frontend/src/__tests__/cypress/cypress/tests/mocked/projects/modelServingNim.cy.ts
@@ -199,7 +199,7 @@ describe('NIM Model Serving', () => {
         validateNvidiaNimModel(findNimModelDeployButton());
       });
 
-      it("When there is a failure in loading Nvidia Nim model images then error message should be displayed.", () => {
+      it("should display an error when failed to fetch nim Nividia model list", () => {
         initInterceptsToEnableNim({});
         const componentName = 'overview';
         projectDetails.visitSection('test-project', componentName);


### PR DESCRIPTION
Added a test case to address there is a failure in loading Nvidia Nim model images then error message should be displayed.

Added experimentalStudio flag to cypress.config.ts but disabled it by default.