### PR TITLE
Adding mockNimEnabledProject mocking function

### DIFF
--- a/frontend/src/__mocks__/mockNimResource.ts
+++ b/frontend/src/__mocks__/mockNimResource.ts
@@ -19,31 +19,26 @@ export const mockNimImages = (): ConfigMapKind =>
     name: 'nvidia-nim-images-data',
     namespace: 'opendatahub',
     data: {
-      alphafold2:
-        '{' +
-        '   "name": "alphafold2",' +
-        '   "displayName": "AlphaFold2",' +
-        '   "shortDescription": "A widely used model for predicting the 3D structures of proteins from their amino acid sequences.",' +
-        '   "namespace": "nim/deepmind",' +
-        '   "tags": [' +
-        '   "1.0.0"' +
-        '   ],' +
-        '   "latestTag": "1.0.0",' +
-        '   "updatedDate": "2024-08-27T01:51:55.642Z"' +
-        '  }',
-      'arctic-embed-l':
-        '{' +
-        '   "name": "arctic-embed-l",' +
-        '   "displayName": "Snowflake Arctic Embed Large Embedding",' +
-        '   "shortDescription": "NVIDIA NIM for GPU accelerated Snowflake Arctic Embed Large Embedding inference",' +
-        '   "namespace": "nim/snowflake",' +
-        '   "tags": [' +
-        '   "1.0.1",' +
-        '   "1.0.0"' +
-        '   ],' +
-        '   "latestTag": "1.0.1",' +
-        '   "updatedDate": "2024-07-27T00:38:40.927Z"' +
-        '  }',
+      alphafold2: JSON.stringify({
+        name: 'alphafold2',
+        displayName: 'AlphaFold2',
+        shortDescription:
+          'A widely used model for predicting the 3D structures of proteins from their amino acid sequences.',
+        namespace: 'nim/deepmind',
+        tags: ['1.0.0'],
+        latestTag: '1.0.0',
+        updatedDate: '2024-08-27T01:51:55.642Z',
+      }),
+      'arctic-embed-l': JSON.stringify({
+        name: 'arctic-embed-l',
+        displayName: 'Snowflake Arctic Embed Large Embedding',
+        shortDescription:
+          'NVIDIA NIM for GPU accelerated Snowflake Arctic Embed Large Embedding inference',
+        namespace: 'nim/snowflake',
+        tags: ['1.0.1', '1.0.0'],
+        latestTag: '1.0.1',
+        updatedDate: '2024-07-27T00:38:40.927Z',
+      }),
     },
   });
 

--- a/frontend/src/__mocks__/mockNimResource.ts
+++ b/frontend/src/__mocks__/mockNimResource.ts
@@ -2,6 +2,7 @@ import {
   ConfigMapKind,
   InferenceServiceKind,
   PersistentVolumeClaimKind,
+  ProjectKind,
   SecretKind,
   ServingRuntimeKind,
   TemplateKind,
@@ -13,6 +14,7 @@ import { mockInferenceServiceK8sResource } from './mockInferenceServiceK8sResour
 import { mockServingRuntimeTemplateK8sResource } from './mockServingRuntimeTemplateK8sResource';
 import { mockSecretK8sResource } from './mockSecretK8sResource';
 import { mockPVCK8sResource } from './mockPVCK8sResource';
+import { mockProjectK8sResource } from './mockProjectK8sResource';
 
 export const mockNimImages = (): ConfigMapKind =>
   mockConfigMap({
@@ -124,4 +126,16 @@ export const mockNimModelPVC = (): PersistentVolumeClaimKind => {
     name: 'nim-pvc',
   });
   return pvc;
+};
+
+export const mockNimEnabledProject = (hasAllModels: boolean): ProjectKind => {
+  const project = mockProjectK8sResource({
+    hasAnnotations: true,
+    enableModelMesh: hasAllModels ? undefined : false,
+  });
+  if (project.metadata.annotations != null) {
+    project.metadata.annotations['opendatahub.io/nim-support'] = 'true';
+  }
+
+  return project;
 };

--- a/frontend/src/__tests__/cypress/cypress/pages/projects.ts
+++ b/frontend/src/__tests__/cypress/cypress/pages/projects.ts
@@ -286,12 +286,86 @@ class ProjectDetails {
     return cy.findByTestId('unsupported-pipeline-version-alert');
   }
 
-  private findKserveModelsTable() {
+  findKserveModelsTable() {
     return cy.findByTestId('kserve-inference-service-table');
   }
 
   getKserveModelMetricLink(name: string) {
     return this.findKserveModelsTable().findByTestId(`metrics-link-${name}`);
+  }
+
+  getKserveTableRow(name: string) {
+    return new KserveTableRow(() =>
+      this.findKserveModelsTable()
+        .find('tbody')
+        .find('[data-label="Name"]')
+        .contains(name)
+        .closest('tr'),
+    );
+  }
+
+  getKserveTableDetailsRow(name: string) {
+    return new KserveTableDetailsRow(() =>
+      this.findKserveModelsTable()
+        .find('tbody')
+        .find('[data-label="Name"]')
+        .contains(name)
+        .closest('tr')
+        .next('tr'),
+    );
+  }
+}
+
+class KserveTableDetailsRow extends TableRow {
+  private findDetailsCell() {
+    return this.find().find('td').eq(1);
+  }
+
+  findValueFor(label: string) {
+    return this.findDetailsCell().find('dt').contains(label).closest('div').find('dd');
+  }
+}
+class KserveTableRow extends TableRow {
+  findColumn(name: string) {
+    return this.find().find(`[data-label="${name}"]`);
+  }
+
+  findStatusTooltip() {
+    return this.find()
+      .findByTestId('status-tooltip')
+      .trigger('mouseenter')
+      .then(() => {
+        cy.findByTestId('model-status-tooltip');
+      });
+  }
+
+  findStatusTooltipValue(msg: string) {
+    this.findStatusTooltip()
+      .invoke('text')
+      .should('contain', msg)
+      .then(() => {
+        this.findStatusTooltip().trigger('mouseleave');
+      });
+  }
+
+  findAPIProtocol() {
+    return this.find().find(`[data-label="API protocol"]`);
+  }
+
+  findInternalServiceButton() {
+    return this.find().findByTestId('internal-service-button');
+  }
+
+  findInternalServicePopover() {
+    return cy.findByTestId('internal-service-popover');
+  }
+
+  findInternalServicePopoverCloseButton() {
+    return this.findInternalServicePopover().find('button');
+  }
+
+  findDetailsTriggerButton() {
+    return this.find().findByTestId('kserve-model-row-item').find('button');
   }
 }
 

--- a/frontend/src/__tests__/cypress/cypress/utils/nimUtils.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/nimUtils.ts
@@ -18,6 +18,7 @@ import {
   TemplateModel,
 } from '~/__tests__/cypress/cypress/utils/models';
 import {
+  mockNimEnabledProject,
   mockNimImages,
   mockNimInferenceService,
   mockNimModelPVC,
@@ -185,13 +186,7 @@ export const initInterceptsToEnableNim = ({ hasAllModels = false }: EnableNimCon
     }),
   );
 
-  const project = mockProjectK8sResource({
-    hasAnnotations: true,
-    enableModelMesh: hasAllModels ? undefined : false,
-  });
-  if (project.metadata.annotations != null) {
-    project.metadata.annotations['opendatahub.io/nim-support'] = 'true';
-  }
+  const project = mockNimEnabledProject(hasAllModels);
   cy.interceptK8sList(ProjectModel, mockK8sResourceList([project]));
 
   const templateMock = mockNimServingRuntimeTemplate();

--- a/frontend/src/__tests__/cypress/cypress/utils/nimUtils.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/nimUtils.ts
@@ -275,6 +275,6 @@ export const initInterceptorsValidatingNimEnablement = (
 
   cy.interceptK8sList(
     ProjectModel,
-    mockK8sResourceList([mockProjectK8sResource({ hasAnnotations: true })]),
+    mockK8sResourceList([mockNimEnabledProject(true)]),
   );
 };

--- a/frontend/src/__tests__/cypress/cypress/utils/nimUtils.ts
+++ b/frontend/src/__tests__/cypress/cypress/utils/nimUtils.ts
@@ -29,6 +29,7 @@ import {
 } from '~/__mocks__/mockNimResource';
 import { mockAcceleratorProfile } from '~/__mocks__/mockAcceleratorProfile';
 import type { InferenceServiceKind } from '~/k8sTypes';
+import { projectDetails } from '~/__tests__/cypress/cypress/pages/projects';
 
 export function findNimModelDeployButton(): Cypress.Chainable<JQuery> {
   return findNimModelServingPlatformCard().findByTestId('nim-serving-deploy-button');
@@ -70,37 +71,39 @@ export function validateNvidiaNimModel(
 
 export function validateNimModelsTable(): void {
   // Table is visible and has 2 rows (2nd is the hidden expandable row)
-  cy.get('[data-testid="kserve-inference-service-table"]')
-    .find('tbody')
-    .find('tr')
-    .should('have.length', 2);
+  const kserveTable = projectDetails.findKserveModelsTable();
+  kserveTable.find('tbody').find('tr').should('have.length', 2);
 
   // First row matches the NIM inference service details
-  cy.get('[style="display: block;"] > :nth-child(1)').should('have.text', 'Test Name');
-  cy.get('[data-label="Serving Runtime"]').should('have.text', 'NVIDIA NIM');
-  cy.get('[data-testid="internal-service-button"]').should('have.text', 'Internal Service');
+  const kserveTableRow = projectDetails.getKserveTableRow('Test Name');
+  kserveTableRow.findColumn('Name').should('have.text', 'Test Name');
+  kserveTableRow.findColumn('Serving Runtime').should('have.text', 'NVIDIA NIM');
+  kserveTableRow.findColumn('Inference endpoint').should('have.text', 'Internal Service');
+  kserveTableRow.findColumn('API protocol').should('have.text', 'REST');
+
   // Validate Internal Service tooltip and close it
-  cy.get('[data-testid="internal-service-button"]').click();
-  cy.get('.pf-v5-c-popover__title-text').should(
-    'have.text',
-    'Internal Service can be accessed inside the cluster',
-  );
-  cy.get('.pf-v5-c-popover__close > .pf-v5-c-button > .pf-v5-svg > path').click();
+  kserveTableRow.findInternalServiceButton().click();
+  kserveTableRow
+    .findInternalServicePopover()
+    .findByText('Internal Service can be accessed inside the cluster')
+    .should('exist');
+  kserveTableRow.findInternalServicePopoverCloseButton().click();
+
   // Open toggle to validate Model details
-  cy.get('.pf-v5-c-table__toggle-icon').click();
-  cy.get(
-    ':nth-child(1) > .pf-v5-c-description-list > .pf-v5-c-description-list__group > .pf-v5-c-description-list__description > .pf-v5-c-description-list__text',
-  ).should('have.text', 'arctic-embed-l');
-  cy.get(
-    ':nth-child(2) > .pf-v5-c-description-list > :nth-child(1) > .pf-v5-c-description-list__description > .pf-v5-c-description-list__text',
-  ).should('have.text', '1');
-  cy.get('.pf-v5-c-list > :nth-child(1)').should('have.text', 'Small');
-  cy.get('.pf-v5-c-list > :nth-child(2)').should('have.text', '1 CPUs, 4Gi Memory requested');
-  cy.get('.pf-v5-c-list > :nth-child(3)').should('have.text', '2 CPUs, 8Gi Memory limit');
-  cy.get(
-    ':nth-child(3) > .pf-v5-c-description-list__description > .pf-v5-c-description-list__text',
-  ).should('have.text', 'No accelerator selected');
-  cy.get('.pf-v5-c-table__toggle-icon').click();
+  kserveTableRow.findDetailsTriggerButton().click();
+  const kserveDetailsTableRow = projectDetails.getKserveTableDetailsRow('Test Name');
+  kserveDetailsTableRow.findValueFor('Framework').should('have.text', 'arctic-embed-l');
+  kserveDetailsTableRow.findValueFor('Model server replicas').should('have.text', '1');
+  kserveDetailsTableRow.findValueFor('Model server size').should('contain.text', 'Small');
+  kserveDetailsTableRow
+    .findValueFor('Model server size')
+    .should('contain.text', '1 CPUs, 4Gi Memory requested');
+  kserveDetailsTableRow
+    .findValueFor('Model server size')
+    .should('contain.text', '2 CPUs, 8Gi Memory limit');
+  kserveDetailsTableRow.findValueFor('Accelerator').should('have.text', 'No accelerator selected');
+
+  kserveTableRow.findDetailsTriggerButton().click();
 }
 
 export function validateNimOverviewModelsTable(): void {
@@ -273,8 +276,5 @@ export const initInterceptorsValidatingNimEnablement = (
     cy.interceptK8s(TemplateModel, templateMock);
   }
 
-  cy.interceptK8sList(
-    ProjectModel,
-    mockK8sResourceList([mockNimEnabledProject(true)]),
-  );
+  cy.interceptK8sList(ProjectModel, mockK8sResourceList([mockNimEnabledProject(true)]));
 };


### PR DESCRIPTION
1st Comment:
```text
[andrewballantyne] I imagine this belgons in the mocks for NIM Resource, no?
```
[Link](https://github.com/opendatahub-io/odh-dashboard/pull/3298#discussion_r1788254523)

2nd comment:
```text
We should definitely be using page objects and not being explicit about test ids like this. cy.findByTestId for instance is also available
```
[Link](https://github.com/opendatahub-io/odh-dashboard/pull/3298#discussion_r1788261923)
